### PR TITLE
improve service aliasing and auto configuration

### DIFF
--- a/src/DynamicSearchBundle/DependencyInjection/Compiler/ContextGuardPass.php
+++ b/src/DynamicSearchBundle/DependencyInjection/Compiler/ContextGuardPass.php
@@ -9,6 +9,8 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 final class ContextGuardPass implements CompilerPassInterface
 {
+    public const CONTEXT_GUARD_TAG = 'dynamic_search.context_guard';
+
     use PriorityTaggedServiceTrait;
 
     /**
@@ -17,7 +19,7 @@ final class ContextGuardPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         $definition = $container->getDefinition(ContextGuardRegistry::class);
-        foreach ($this->findAndSortTaggedServices('dynamic_search.context_guard', $container) as $reference) {
+        foreach ($this->findAndSortTaggedServices(self::CONTEXT_GUARD_TAG, $container) as $reference) {
             $definition->addMethodCall('register', [$reference]);
         }
     }

--- a/src/DynamicSearchBundle/DependencyInjection/Compiler/DefinitionBuilderPass.php
+++ b/src/DynamicSearchBundle/DependencyInjection/Compiler/DefinitionBuilderPass.php
@@ -11,6 +11,9 @@ final class DefinitionBuilderPass implements CompilerPassInterface
 {
     use PriorityTaggedServiceTrait;
 
+    public const DOCUMENT_DEFINITION_BUILDER = 'dynamic_search.document_definition_builder';
+    public const FILTER_DEFINITION_BUILDER = 'dynamic_search.filter_definition_builder';
+
     /**
      * {@inheritdoc}
      */
@@ -18,11 +21,11 @@ final class DefinitionBuilderPass implements CompilerPassInterface
     {
         $definition = $container->getDefinition(DefinitionBuilderRegistry::class);
 
-        foreach ($this->findAndSortTaggedServices('dynamic_search.document_definition_builder', $container) as $reference) {
+        foreach ($this->findAndSortTaggedServices(self::DOCUMENT_DEFINITION_BUILDER, $container) as $reference) {
             $definition->addMethodCall('registerDocumentDefinition', [$reference]);
         }
 
-        foreach ($this->findAndSortTaggedServices('dynamic_search.filter_definition_builder', $container) as $reference) {
+        foreach ($this->findAndSortTaggedServices(self::FILTER_DEFINITION_BUILDER, $container) as $reference) {
             $definition->addMethodCall('registerFilterDefinition', [$reference]);
         }
     }

--- a/src/DynamicSearchBundle/DependencyInjection/Compiler/IndexPass.php
+++ b/src/DynamicSearchBundle/DependencyInjection/Compiler/IndexPass.php
@@ -9,22 +9,27 @@ use Symfony\Component\DependencyInjection\Reference;
 
 final class IndexPass implements CompilerPassInterface
 {
+    public const INDEX_FIELD_TAG = 'dynamic_search.index.field';
+    public const INDEX_FILTER_TAG = 'dynamic_search.index.filter';
+
     /**
      * {@inheritdoc}
      */
     public function process(ContainerBuilder $container)
     {
-        foreach ($container->findTaggedServiceIds('dynamic_search.index.field', true) as $id => $tags) {
+        foreach ($container->findTaggedServiceIds(self::INDEX_FIELD_TAG, true) as $id => $tags) {
             $definition = $container->getDefinition(IndexRegistry::class);
             foreach ($tags as $attributes) {
-                $definition->addMethodCall('registerField', [new Reference($id), $attributes['identifier'], $attributes['index_provider']]);
+                $alias = isset($attributes['identifier']) ? $attributes['identifier'] : null;
+                $definition->addMethodCall('registerField', [new Reference($id), $id, $alias, $attributes['index_provider']]);
             }
         }
 
-        foreach ($container->findTaggedServiceIds('dynamic_search.index.filter', true) as $id => $tags) {
+        foreach ($container->findTaggedServiceIds(self::INDEX_FILTER_TAG, true) as $id => $tags) {
             $definition = $container->getDefinition(IndexRegistry::class);
             foreach ($tags as $attributes) {
-                $definition->addMethodCall('registerFilter', [new Reference($id), $attributes['identifier'], $attributes['index_provider']]);
+                $alias = isset($attributes['identifier']) ? $attributes['identifier'] : null;
+                $definition->addMethodCall('registerFilter', [new Reference($id), $id, $alias, $attributes['index_provider']]);
             }
         }
     }

--- a/src/DynamicSearchBundle/Generator/IndexDocumentGenerator.php
+++ b/src/DynamicSearchBundle/Generator/IndexDocumentGenerator.php
@@ -257,6 +257,7 @@ class IndexDocumentGenerator implements IndexDocumentGeneratorInterface
         $fieldTransformerConfiguration = $options['configuration'];
 
         $fieldTransformer = $this->transformerManager->getResourceFieldTransformer($dispatchTransformerName, $fieldTransformerName, $fieldTransformerConfiguration);
+
         if (!$fieldTransformer instanceof FieldTransformerInterface) {
             return null;
         }

--- a/src/DynamicSearchBundle/Registry/ContextGuardRegistry.php
+++ b/src/DynamicSearchBundle/Registry/ContextGuardRegistry.php
@@ -22,19 +22,7 @@ class ContextGuardRegistry implements ContextGuardRegistryInterface
      */
     public function register($service)
     {
-        if (!in_array(ContextGuardInterface::class, class_implements($service), true)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    '%s needs to implement "%s", "%s" given.',
-                    get_class($service),
-                    ContextGuardInterface::class,
-                    implode(', ', class_implements($service))
-                )
-            );
-        }
-
-        $this->registryStorage->store($service, 'contextGuard', get_class($service));
-
+        $this->registryStorage->store($service, ContextGuardInterface::class,'contextGuard', get_class($service));
     }
 
     /**

--- a/src/DynamicSearchBundle/Registry/ContextGuardRegistry.php
+++ b/src/DynamicSearchBundle/Registry/ContextGuardRegistry.php
@@ -3,13 +3,19 @@
 namespace DynamicSearchBundle\Registry;
 
 use DynamicSearchBundle\Guard\ContextGuardInterface;
+use DynamicSearchBundle\Registry\Storage\RegistryStorage;
 
 class ContextGuardRegistry implements ContextGuardRegistryInterface
 {
     /**
-     * @var array
+     * @var RegistryStorage
      */
-    protected $guards;
+    protected $registryStorage;
+
+    public function __construct()
+    {
+        $this->registryStorage = new RegistryStorage();
+    }
 
     /**
      * @param ContextGuardInterface $service
@@ -27,7 +33,8 @@ class ContextGuardRegistry implements ContextGuardRegistryInterface
             );
         }
 
-        $this->guards[] = $service;
+        $this->registryStorage->store($service, 'contextGuard', get_class($service));
+
     }
 
     /**
@@ -35,6 +42,6 @@ class ContextGuardRegistry implements ContextGuardRegistryInterface
      */
     public function getAllGuards()
     {
-        return !is_array($this->guards) ? [] : $this->guards;
+        return $this->registryStorage->getByNamespace('contextGuard');
     }
 }

--- a/src/DynamicSearchBundle/Registry/DataProviderRegistry.php
+++ b/src/DynamicSearchBundle/Registry/DataProviderRegistry.php
@@ -3,19 +3,26 @@
 namespace DynamicSearchBundle\Registry;
 
 use DynamicSearchBundle\Provider\DataProviderInterface;
+use DynamicSearchBundle\Registry\Storage\RegistryStorage;
 
 class DataProviderRegistry implements DataProviderRegistryInterface
 {
     /**
-     * @var array
+     * @var RegistryStorage
      */
-    protected $provider;
+    protected $registryStorage;
+
+    public function __construct()
+    {
+        $this->registryStorage = new RegistryStorage();
+    }
 
     /**
      * @param DataProviderInterface $service
      * @param string                $identifier
+     * @param string|null           $alias
      */
-    public function register($service, $identifier)
+    public function register($service, string $identifier, ?string $alias)
     {
         if (!in_array(DataProviderInterface::class, class_implements($service), true)) {
             throw new \InvalidArgumentException(
@@ -23,7 +30,7 @@ class DataProviderRegistry implements DataProviderRegistryInterface
             );
         }
 
-        $this->provider[$identifier] = $service;
+        $this->registryStorage->store($service, 'dataProvider', $identifier, $alias);
     }
 
     /**
@@ -31,7 +38,7 @@ class DataProviderRegistry implements DataProviderRegistryInterface
      */
     public function has($identifier)
     {
-        return isset($this->provider[$identifier]);
+        return $this->registryStorage->has('dataProvider', $identifier);
     }
 
     /**
@@ -39,10 +46,6 @@ class DataProviderRegistry implements DataProviderRegistryInterface
      */
     public function get($identifier)
     {
-        if (!$this->has($identifier)) {
-            throw new \Exception('"' . $identifier . '" Data Provider does not exist');
-        }
-
-        return $this->provider[$identifier];
+        return $this->registryStorage->get('dataProvider', $identifier);
     }
 }

--- a/src/DynamicSearchBundle/Registry/DataProviderRegistry.php
+++ b/src/DynamicSearchBundle/Registry/DataProviderRegistry.php
@@ -24,13 +24,7 @@ class DataProviderRegistry implements DataProviderRegistryInterface
      */
     public function register($service, string $identifier, ?string $alias)
     {
-        if (!in_array(DataProviderInterface::class, class_implements($service), true)) {
-            throw new \InvalidArgumentException(
-                sprintf('%s needs to implement "%s", "%s" given.', get_class($service), DataProviderInterface::class, implode(', ', class_implements($service)))
-            );
-        }
-
-        $this->registryStorage->store($service, 'dataProvider', $identifier, $alias);
+        $this->registryStorage->store($service, DataProviderInterface::class, 'dataProvider', $identifier, $alias);
     }
 
     /**

--- a/src/DynamicSearchBundle/Registry/DefinitionBuilderRegistry.php
+++ b/src/DynamicSearchBundle/Registry/DefinitionBuilderRegistry.php
@@ -23,18 +23,7 @@ class DefinitionBuilderRegistry implements DefinitionBuilderRegistryInterface
      */
     public function registerDocumentDefinition($service)
     {
-        if (!in_array(DocumentDefinitionBuilderInterface::class, class_implements($service), true)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    '%s needs to implement "%s", "%s" given.',
-                    get_class($service),
-                    DocumentDefinitionBuilderInterface::class,
-                    implode(', ', class_implements($service))
-                )
-            );
-        }
-
-        $this->registryStorage->store($service, 'documentDefinitionBuilder', get_class($service));
+        $this->registryStorage->store($service, DocumentDefinitionBuilderInterface::class, 'documentDefinitionBuilder', get_class($service));
     }
 
     /**
@@ -42,18 +31,7 @@ class DefinitionBuilderRegistry implements DefinitionBuilderRegistryInterface
      */
     public function registerFilterDefinition($service)
     {
-        if (!in_array(FilterDefinitionBuilderInterface::class, class_implements($service), true)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    '%s needs to implement "%s", "%s" given.',
-                    get_class($service),
-                    FilterDefinitionBuilderInterface::class,
-                    implode(', ', class_implements($service))
-                )
-            );
-        }
-
-        $this->registryStorage->store($service, 'filterDefinitionBuilder', get_class($service));
+        $this->registryStorage->store($service, FilterDefinitionBuilderInterface::class, 'filterDefinitionBuilder', get_class($service));
     }
 
     /**

--- a/src/DynamicSearchBundle/Registry/DefinitionBuilderRegistry.php
+++ b/src/DynamicSearchBundle/Registry/DefinitionBuilderRegistry.php
@@ -4,18 +4,19 @@ namespace DynamicSearchBundle\Registry;
 
 use DynamicSearchBundle\Document\Definition\DocumentDefinitionBuilderInterface;
 use DynamicSearchBundle\Filter\Definition\FilterDefinitionBuilderInterface;
+use DynamicSearchBundle\Registry\Storage\RegistryStorage;
 
 class DefinitionBuilderRegistry implements DefinitionBuilderRegistryInterface
 {
     /**
-     * @var array
+     * @var RegistryStorage
      */
-    protected $documentDefinitionBuilder;
+    protected $registryStorage;
 
-    /**
-     * @var array
-     */
-    protected $filterDefinitionBuilder;
+    public function __construct()
+    {
+        $this->registryStorage = new RegistryStorage();
+    }
 
     /**
      * @param DocumentDefinitionBuilderInterface $service
@@ -33,7 +34,7 @@ class DefinitionBuilderRegistry implements DefinitionBuilderRegistryInterface
             );
         }
 
-        $this->documentDefinitionBuilder[] = $service;
+        $this->registryStorage->store($service, 'documentDefinitionBuilder', get_class($service));
     }
 
     /**
@@ -52,7 +53,7 @@ class DefinitionBuilderRegistry implements DefinitionBuilderRegistryInterface
             );
         }
 
-        $this->filterDefinitionBuilder[] = $service;
+        $this->registryStorage->store($service, 'filterDefinitionBuilder', get_class($service));
     }
 
     /**
@@ -60,7 +61,7 @@ class DefinitionBuilderRegistry implements DefinitionBuilderRegistryInterface
      */
     public function getAllDocumentDefinitionBuilder()
     {
-        return !is_array($this->documentDefinitionBuilder) ? [] : $this->documentDefinitionBuilder;
+        return $this->registryStorage->getByNamespace('documentDefinitionBuilder');
     }
 
     /**
@@ -68,6 +69,6 @@ class DefinitionBuilderRegistry implements DefinitionBuilderRegistryInterface
      */
     public function getAllFilterDefinitionBuilder()
     {
-        return !is_array($this->filterDefinitionBuilder) ? [] : $this->filterDefinitionBuilder;
+        return $this->registryStorage->getByNamespace('filterDefinitionBuilder');
     }
 }

--- a/src/DynamicSearchBundle/Registry/IndexProviderRegistry.php
+++ b/src/DynamicSearchBundle/Registry/IndexProviderRegistry.php
@@ -3,19 +3,26 @@
 namespace DynamicSearchBundle\Registry;
 
 use DynamicSearchBundle\Provider\IndexProviderInterface;
+use DynamicSearchBundle\Registry\Storage\RegistryStorage;
 
 class IndexProviderRegistry implements IndexProviderRegistryInterface
 {
     /**
-     * @var array
+     * @var RegistryStorage
      */
-    protected $provider;
+    protected $registryStorage;
+
+    public function __construct()
+    {
+        $this->registryStorage = new RegistryStorage();
+    }
 
     /**
      * @param IndexProviderInterface $service
      * @param string                 $identifier
+     * @param string|null            $alias
      */
-    public function register($service, string $identifier)
+    public function register($service, string $identifier, ?string $alias)
     {
         if (!in_array(IndexProviderInterface::class, class_implements($service), true)) {
             throw new \InvalidArgumentException(
@@ -23,7 +30,7 @@ class IndexProviderRegistry implements IndexProviderRegistryInterface
             );
         }
 
-        $this->provider[$identifier] = $service;
+        $this->registryStorage->store($service, 'indexProvider', $identifier, $alias);
     }
 
     /**
@@ -31,7 +38,7 @@ class IndexProviderRegistry implements IndexProviderRegistryInterface
      */
     public function has(string $identifier)
     {
-        return isset($this->provider[$identifier]);
+        return $this->registryStorage->has('indexProvider', $identifier);
     }
 
     /**
@@ -39,10 +46,6 @@ class IndexProviderRegistry implements IndexProviderRegistryInterface
      */
     public function get(string $identifier)
     {
-        if (!$this->has($identifier)) {
-            throw new \Exception('"' . $identifier . '" Index Provider does not exist');
-        }
-
-        return $this->provider[$identifier];
+        return $this->registryStorage->get('indexProvider', $identifier);
     }
 }

--- a/src/DynamicSearchBundle/Registry/IndexProviderRegistry.php
+++ b/src/DynamicSearchBundle/Registry/IndexProviderRegistry.php
@@ -24,13 +24,7 @@ class IndexProviderRegistry implements IndexProviderRegistryInterface
      */
     public function register($service, string $identifier, ?string $alias)
     {
-        if (!in_array(IndexProviderInterface::class, class_implements($service), true)) {
-            throw new \InvalidArgumentException(
-                sprintf('%s needs to implement "%s", "%s" given.', get_class($service), IndexProviderInterface::class, implode(', ', class_implements($service)))
-            );
-        }
-
-        $this->registryStorage->store($service, 'indexProvider', $identifier, $alias);
+        $this->registryStorage->store($service, IndexProviderInterface::class, 'indexProvider', $identifier, $alias);
     }
 
     /**

--- a/src/DynamicSearchBundle/Registry/IndexRegistry.php
+++ b/src/DynamicSearchBundle/Registry/IndexRegistry.php
@@ -26,14 +26,8 @@ class IndexRegistry implements IndexRegistryInterface
      */
     public function registerField($service, string $identifier, ?string $alias, string $indexProviderName)
     {
-        if (!in_array(IndexFieldInterface::class, class_implements($service), true)) {
-            throw new \InvalidArgumentException(
-                sprintf('%s needs to implement "%s", "%s" given.', get_class($service), IndexFieldInterface::class, implode(', ', class_implements($service)))
-            );
-        }
-
         $namespace = sprintf('fields_%s', $indexProviderName);
-        $this->registryStorage->store($service, $namespace, $identifier, $alias);
+        $this->registryStorage->store($service, IndexFieldInterface::class, $namespace, $identifier, $alias);
     }
 
     /**
@@ -44,14 +38,8 @@ class IndexRegistry implements IndexRegistryInterface
      */
     public function registerFilter($service, string $identifier, ?string $alias, string $indexProviderName)
     {
-        if (!in_array(FilterInterface::class, class_implements($service), true)) {
-            throw new \InvalidArgumentException(
-                sprintf('%s needs to implement "%s", "%s" given.', get_class($service), FilterInterface::class, implode(', ', class_implements($service)))
-            );
-        }
-
         $namespace = sprintf('filter_%s', $indexProviderName);
-        $this->registryStorage->store($service, $namespace, $identifier, $alias);
+        $this->registryStorage->store($service, FilterInterface::class, $namespace, $identifier, $alias);
     }
 
     /**

--- a/src/DynamicSearchBundle/Registry/OutputChannelRegistry.php
+++ b/src/DynamicSearchBundle/Registry/OutputChannelRegistry.php
@@ -28,18 +28,7 @@ class OutputChannelRegistry implements OutputChannelRegistryInterface
      */
     public function registerOutputChannelService($service, string $identifier, ?string $alias)
     {
-        if (!in_array(OutputChannelInterface::class, class_implements($service), true)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    '%s needs to implement "%s", "%s" given.',
-                    get_class($service),
-                    OutputChannelInterface::class,
-                    implode(', ', class_implements($service))
-                )
-            );
-        }
-
-        $this->registryStorage->store($service, 'outputChannel', $identifier, $alias);
+        $this->registryStorage->store($service, OutputChannelInterface::class, 'outputChannel', $identifier, $alias);
     }
 
     /**
@@ -49,18 +38,7 @@ class OutputChannelRegistry implements OutputChannelRegistryInterface
      */
     public function registerOutputChannelRuntimeQueryProvider($service, string $identifier, ?string $alias)
     {
-        if (!in_array(RuntimeQueryProviderInterface::class, class_implements($service), true)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    '%s needs to implement "%s", "%s" given.',
-                    get_class($service),
-                    RuntimeQueryProviderInterface::class,
-                    implode(', ', class_implements($service))
-                )
-            );
-        }
-
-        $this->registryStorage->store($service, 'runtimeQueryProvider', $identifier, $alias);
+        $this->registryStorage->store($service, RuntimeQueryProviderInterface::class, 'runtimeQueryProvider', $identifier, $alias);
     }
 
     /**
@@ -70,18 +48,7 @@ class OutputChannelRegistry implements OutputChannelRegistryInterface
      */
     public function registerOutputChannelRuntimeOptionsBuilder($service, string $identifier, ?string $alias)
     {
-        if (!in_array(RuntimeOptionsBuilderInterface::class, class_implements($service), true)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    '%s needs to implement "%s", "%s" given.',
-                    get_class($service),
-                    RuntimeOptionsBuilderInterface::class,
-                    implode(', ', class_implements($service))
-                )
-            );
-        }
-
-        $this->registryStorage->store($service, 'runtimeOptionsBuilder', $identifier, $alias);
+        $this->registryStorage->store($service, RuntimeOptionsBuilderInterface::class, 'runtimeOptionsBuilder', $identifier, $alias);
     }
 
     /**
@@ -91,19 +58,8 @@ class OutputChannelRegistry implements OutputChannelRegistryInterface
      */
     public function registerOutputChannelModifierAction($service, string $outputChannelService, string $action)
     {
-        if (!in_array(OutputChannelModifierActionInterface::class, class_implements($service), true)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    '%s needs to implement "%s", "%s" given.',
-                    get_class($service),
-                    OutputChannelModifierActionInterface::class,
-                    implode(', ', class_implements($service))
-                )
-            );
-        }
-
         $namespace = sprintf('outputChannelModifierAction_%s_%s', $outputChannelService, $action);
-        $this->registryStorage->store($service, $namespace, null, null, true);
+        $this->registryStorage->store($service, OutputChannelModifierActionInterface::class, $namespace, null, null, true);
     }
 
     /**
@@ -113,19 +69,8 @@ class OutputChannelRegistry implements OutputChannelRegistryInterface
      */
     public function registerOutputChannelModifierFilter($service, string $outputChannelService, string $filter)
     {
-        if (!in_array(OutputChannelModifierFilterInterface::class, class_implements($service), true)) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    '%s needs to implement "%s", "%s" given.',
-                    get_class($service),
-                    OutputChannelModifierFilterInterface::class,
-                    implode(', ', class_implements($service))
-                )
-            );
-        }
-
         $namespace = sprintf('outputChannelModifierFilter_%s', $outputChannelService);
-        $this->registryStorage->store($service, $namespace, $filter);
+        $this->registryStorage->store($service, OutputChannelModifierFilterInterface::class, $namespace, $filter);
     }
 
     /**

--- a/src/DynamicSearchBundle/Registry/OutputChannelRegistry.php
+++ b/src/DynamicSearchBundle/Registry/OutputChannelRegistry.php
@@ -103,7 +103,7 @@ class OutputChannelRegistry implements OutputChannelRegistryInterface
         }
 
         $namespace = sprintf('outputChannelModifierAction_%s_%s', $outputChannelService, $action);
-        $this->registryStorage->store($service, $namespace, $action);
+        $this->registryStorage->store($service, $namespace, null, null, true);
     }
 
     /**
@@ -181,7 +181,7 @@ class OutputChannelRegistry implements OutputChannelRegistryInterface
      */
     public function hasOutputChannelModifierAction(string $outputChannelServiceName, string $action)
     {
-        $namespace = sprintf('outputChannelModifierAction_%s_%s', $outputChannelService, $action);
+        $namespace = sprintf('outputChannelModifierAction_%s_%s', $outputChannelServiceName, $action);
 
         return $this->registryStorage->hasOneByNamespace($namespace);
     }
@@ -191,7 +191,7 @@ class OutputChannelRegistry implements OutputChannelRegistryInterface
      */
     public function getOutputChannelModifierAction(string $outputChannelServiceName, string $action)
     {
-        $namespace = sprintf('outputChannelModifierAction_%s_%s', $outputChannelService, $action);
+        $namespace = sprintf('outputChannelModifierAction_%s_%s', $outputChannelServiceName, $action);
 
         return $this->registryStorage->getByNamespace($namespace);
     }
@@ -201,7 +201,7 @@ class OutputChannelRegistry implements OutputChannelRegistryInterface
      */
     public function hasOutputChannelModifierFilter(string $outputChannelServiceName, string $filter)
     {
-        $namespace = sprintf('outputChannelModifierFilter_%s', $outputChannelService);
+        $namespace = sprintf('outputChannelModifierFilter_%s', $outputChannelServiceName);
 
         return $this->registryStorage->has($namespace, $filter);
     }
@@ -211,7 +211,7 @@ class OutputChannelRegistry implements OutputChannelRegistryInterface
      */
     public function getOutputChannelModifierFilter(string $outputChannelServiceName, string $filter)
     {
-        $namespace = sprintf('outputChannelModifierFilter_%s', $outputChannelService);
+        $namespace = sprintf('outputChannelModifierFilter_%s', $outputChannelServiceName);
 
         return $this->registryStorage->get($namespace, $filter);
     }

--- a/src/DynamicSearchBundle/Registry/ResourceNormalizerRegistry.php
+++ b/src/DynamicSearchBundle/Registry/ResourceNormalizerRegistry.php
@@ -26,14 +26,8 @@ class ResourceNormalizerRegistry implements ResourceNormalizerRegistryInterface
      */
     public function registerResourceNormalizer($service, string $identifier, ?string $alias, string $dataProviderName)
     {
-        if (!in_array(ResourceNormalizerInterface::class, class_implements($service), true)) {
-            throw new \InvalidArgumentException(
-                sprintf('%s needs to implement "%s", "%s" given.', get_class($service), ResourceNormalizerInterface::class, implode(', ', class_implements($service)))
-            );
-        }
-
         $namespace = sprintf('resourceNormalizer_%s', $dataProviderName);
-        $this->registryStorage->store($service, $namespace, $identifier, $alias);
+        $this->registryStorage->store($service, ResourceNormalizerInterface::class, $namespace, $identifier, $alias);
     }
 
     /**
@@ -44,14 +38,8 @@ class ResourceNormalizerRegistry implements ResourceNormalizerRegistryInterface
      */
     public function registerDocumentNormalizer($service, string $identifier, ?string $alias, string $indexProviderName)
     {
-        if (!in_array(DocumentNormalizerInterface::class, class_implements($service), true)) {
-            throw new \InvalidArgumentException(
-                sprintf('%s needs to implement "%s", "%s" given.', get_class($service), DocumentNormalizerInterface::class, implode(', ', class_implements($service)))
-            );
-        }
-
         $namespace = sprintf('documentNormalizer_%s', $indexProviderName);
-        $this->registryStorage->store($service, $namespace, $identifier, $alias);
+        $this->registryStorage->store($service, DocumentNormalizerInterface::class, $namespace, $identifier, $alias);
     }
 
     /**

--- a/src/DynamicSearchBundle/Registry/ResourceNormalizerRegistry.php
+++ b/src/DynamicSearchBundle/Registry/ResourceNormalizerRegistry.php
@@ -4,20 +4,27 @@ namespace DynamicSearchBundle\Registry;
 
 use DynamicSearchBundle\Normalizer\DocumentNormalizerInterface;
 use DynamicSearchBundle\Normalizer\ResourceNormalizerInterface;
+use DynamicSearchBundle\Registry\Storage\RegistryStorage;
 
 class ResourceNormalizerRegistry implements ResourceNormalizerRegistryInterface
 {
     /**
-     * @var array
+     * @var RegistryStorage
      */
-    protected $normalizer;
+    protected $registryStorage;
+
+    public function __construct()
+    {
+        $this->registryStorage = new RegistryStorage();
+    }
 
     /**
      * @param ResourceNormalizerInterface $service
      * @param string                      $identifier
+     * @param string|null                 $alias
      * @param string                      $dataProviderName
      */
-    public function registerResourceNormalizer($service, string $identifier, string $dataProviderName)
+    public function registerResourceNormalizer($service, string $identifier, ?string $alias, string $dataProviderName)
     {
         if (!in_array(ResourceNormalizerInterface::class, class_implements($service), true)) {
             throw new \InvalidArgumentException(
@@ -25,23 +32,17 @@ class ResourceNormalizerRegistry implements ResourceNormalizerRegistryInterface
             );
         }
 
-        if (!isset($this->normalizer['resource'])) {
-            $this->normalizer['resource'] = [];
-        }
-
-        if (!isset($this->normalizer['resource'][$dataProviderName])) {
-            $this->normalizer['resource'][$dataProviderName] = [];
-        }
-
-        $this->normalizer['resource'][$dataProviderName][$identifier] = $service;
+        $namespace = sprintf('resourceNormalizer_%s', $dataProviderName);
+        $this->registryStorage->store($service, $namespace, $identifier, $alias);
     }
 
     /**
      * @param DocumentNormalizerInterface $service
      * @param string                      $identifier
+     * @param string|null                 $alias
      * @param string                      $indexProviderName
      */
-    public function registerDocumentNormalizer($service, string $identifier, string $indexProviderName)
+    public function registerDocumentNormalizer($service, string $identifier, ?string $alias, string $indexProviderName)
     {
         if (!in_array(DocumentNormalizerInterface::class, class_implements($service), true)) {
             throw new \InvalidArgumentException(
@@ -49,15 +50,8 @@ class ResourceNormalizerRegistry implements ResourceNormalizerRegistryInterface
             );
         }
 
-        if (!isset($this->normalizer['document'])) {
-            $this->normalizer['document'] = [];
-        }
-
-        if (!isset($this->normalizer['document'][$indexProviderName])) {
-            $this->normalizer['document'][$indexProviderName] = [];
-        }
-
-        $this->normalizer['document'][$indexProviderName][$identifier] = $service;
+        $namespace = sprintf('documentNormalizer_%s', $indexProviderName);
+        $this->registryStorage->store($service, $namespace, $identifier, $alias);
     }
 
     /**
@@ -65,7 +59,9 @@ class ResourceNormalizerRegistry implements ResourceNormalizerRegistryInterface
      */
     public function getResourceNormalizerForDataProvider(string $dataProviderName, string $identifier)
     {
-        return $this->normalizer['resource'][$dataProviderName][$identifier];
+        $namespace = sprintf('resourceNormalizer_%s', $dataProviderName);
+
+        return $this->registryStorage->get($namespace, $identifier);
     }
 
     /**
@@ -73,7 +69,9 @@ class ResourceNormalizerRegistry implements ResourceNormalizerRegistryInterface
      */
     public function hasResourceNormalizerForDataProvider(string $dataProviderName, string $identifier)
     {
-        return isset($this->normalizer['resource'][$dataProviderName]) && isset($this->normalizer['resource'][$dataProviderName][$identifier]);
+        $namespace = sprintf('resourceNormalizer_%s', $dataProviderName);
+
+        return $this->registryStorage->has($namespace, $identifier);
     }
 
     /**
@@ -81,7 +79,9 @@ class ResourceNormalizerRegistry implements ResourceNormalizerRegistryInterface
      */
     public function getDocumentNormalizerForIndexProvider(string $indexProviderName, string $identifier)
     {
-        return $this->normalizer['document'][$indexProviderName][$identifier];
+        $namespace = sprintf('documentNormalizer_%s', $indexProviderName);
+
+        return $this->registryStorage->get($namespace, $identifier);
     }
 
     /**
@@ -89,6 +89,8 @@ class ResourceNormalizerRegistry implements ResourceNormalizerRegistryInterface
      */
     public function hasDocumentNormalizerForIndexProvider(string $indexProviderName, string $identifier)
     {
-        return isset($this->normalizer['document'][$indexProviderName]) && isset($this->normalizer['document'][$indexProviderName][$identifier]);
+        $namespace = sprintf('documentNormalizer_%s', $indexProviderName);
+
+        return $this->registryStorage->has($namespace, $identifier);
     }
 }

--- a/src/DynamicSearchBundle/Registry/Storage/RegistryStorage.php
+++ b/src/DynamicSearchBundle/Registry/Storage/RegistryStorage.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace DynamicSearchBundle\Registry\Storage;
+
+use Symfony\Component\DependencyInjection\Reference;
+
+class RegistryStorage
+{
+    /**
+     * @var array
+     */
+    protected $store;
+
+    public function __construct()
+    {
+        $this->store = [];
+    }
+
+    /**
+     * @param Reference   $service
+     * @param string      $namespace
+     * @param string      $identifier
+     * @param string|null $alias
+     *
+     * @throws \Exception
+     */
+    public function store($service, $namespace, $identifier, $alias = null)
+    {
+        if (!isset($this->store[$namespace])) {
+            $this->store[$namespace] = [];
+        }
+
+        if ($identifier === $alias) {
+            throw new \Exception(sprintf('Alias "%s" for Servivce "%s" cannot be identical', $alias, $identifier));
+        }
+
+        if ($this->getByIdentifier($namespace, $identifier) !== null) {
+            throw new \Exception(sprintf('Service "%s" for namespace "%s" already has been registered', $identifier, $namespace));
+        } elseif ($this->getByAlias($namespace, $alias) !== null) {
+            throw new \Exception(sprintf('Service "%s" for namespace "%s" with alias "%s" already has been registered', $identifier, $namespace, $alias));
+        }
+
+        $this->store[] = [
+            'identifier' => $identifier,
+            'namespace'  => $namespace,
+            'alias'      => $alias,
+            'service'    => $service,
+        ];
+    }
+
+    /**
+     * @param string $namespace
+     * @param string $identififer
+     * @param string $alias
+     *
+     * @return bool
+     */
+    public function has($namespace, $identififer)
+    {
+        return $this->get($namespace, $identififer) !== null;
+    }
+
+    /**
+     * @param string $namespace
+     *
+     * @return array
+     */
+    public function hasOneByNamespace($namespace)
+    {
+        return count(array_filter($this->store, function ($entry) use ($namespace) {
+                return $entry['namespace'] === $namespace;
+            })) > 0;
+    }
+
+    /**
+     * @param string $namespace
+     * @param string $identififer
+     * @param string $alias
+     *
+     * @return mixed|null
+     */
+    public function get($namespace, $identififer)
+    {
+        if (null !== $byIdentifier = $this->getByIdentifier($namespace, $identififer)) {
+            return $byIdentifier;
+        } elseif (null !== $byAlias = $this->getByAlias($namespace, $identififer)) {
+            return $byAlias;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $namespace
+     *
+     * @return array
+     */
+    public function getByNamespace($namespace)
+    {
+        $validRows = array_filter($this->store, function ($entry) use ($namespace) {
+            return $entry['namespace'] === $namespace;
+        });
+
+        $items = [];
+        foreach ($validRows as $row) {
+            $identifier = $row['alias'] !== null ? $row['alias'] : $row['identifier'];
+            $items[$identifier] = $row['service'];
+        }
+
+        return $items;
+    }
+
+    /**
+     * @param string $namespace
+     * @param string $identififer
+     *
+     * @return mixed|null
+     */
+    protected function getByIdentifier($namespace, $identififer)
+    {
+        foreach ($this->store as $entry) {
+            if ($entry['namespace'] === $namespace && $entry['identifier'] === $identififer) {
+                return $entry['service'];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string      $namespace
+     * @param string|null $alias
+     *
+     * @return mixed|null
+     */
+    protected function getByAlias($namespace, $alias)
+    {
+        if ($alias === null) {
+            return null;
+        }
+
+        foreach ($this->store as $entry) {
+            if ($entry['namespace'] === $namespace && $entry['alias'] === $alias) {
+                return $entry['service'];
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/src/DynamicSearchBundle/Registry/Storage/RegistryStorage.php
+++ b/src/DynamicSearchBundle/Registry/Storage/RegistryStorage.php
@@ -18,6 +18,7 @@ class RegistryStorage
 
     /**
      * @param Reference   $service
+     * @param string      $requiredInterface
      * @param string      $namespace
      * @param string      $identifier
      * @param string|null $alias
@@ -25,10 +26,21 @@ class RegistryStorage
      *
      * @throws \Exception
      */
-    public function store($service, $namespace, $identifier, $alias = null, $allowMultipleAppearance = false)
+    public function store($service, $requiredInterface, $namespace, $identifier, $alias = null, $allowMultipleAppearance = false)
     {
         if (!isset($this->store[$namespace])) {
             $this->store[$namespace] = [];
+        }
+
+        if (!in_array($requiredInterface, class_implements($service), true)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    '%s needs to implement "%s", "%s" given.',
+                    get_class($service),
+                    $requiredInterface,
+                    implode(', ', class_implements($service))
+                )
+            );
         }
 
         if ($allowMultipleAppearance === false) {

--- a/src/DynamicSearchBundle/Registry/TransformerRegistry.php
+++ b/src/DynamicSearchBundle/Registry/TransformerRegistry.php
@@ -26,13 +26,7 @@ class TransformerRegistry implements TransformerRegistryInterface
      */
     public function registerResourceScaffolder($service, string $identifier, ?string $alias, string $dataProvider)
     {
-        if (!in_array(ResourceScaffolderInterface::class, class_implements($service), true)) {
-            throw new \InvalidArgumentException(
-                sprintf('%s needs to implement "%s", "%s" given.', get_class($service), ResourceScaffolderInterface::class, implode(', ', class_implements($service)))
-            );
-        }
-
-        $this->registryStorage->store($service, $dataProvider, $identifier, $alias);
+        $this->registryStorage->store($service, ResourceScaffolderInterface::class, $dataProvider, $identifier, $alias);
     }
 
     /**
@@ -43,13 +37,7 @@ class TransformerRegistry implements TransformerRegistryInterface
      */
     public function registerResourceFieldTransformer($service, string $identifier, ?string $alias, string $resourceScaffolder)
     {
-        if (!in_array(FieldTransformerInterface::class, class_implements($service), true)) {
-            throw new \InvalidArgumentException(
-                sprintf('%s needs to implement "%s", "%s" given.', get_class($service), FieldTransformerInterface::class, implode(', ', class_implements($service)))
-            );
-        }
-
-        $this->registryStorage->store($service, $resourceScaffolder, $identifier, $alias);
+        $this->registryStorage->store($service, FieldTransformerInterface::class, $resourceScaffolder, $identifier, $alias);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | yes
| Fixed tickets | #12

- Service Tag `identifier` is optional now. Services can be registered by using class names only
- Autoconfiguration for DocumentDefinition, FilteDefinition and ContextGuard added (Transformers can't be auto registered due to the requirement of additional tag configuration)
