### PR TITLE
Fix issue #45

### DIFF
--- a/src/DynamicSearchBundle/Registry/DefinitionBuilderRegistry.php
+++ b/src/DynamicSearchBundle/Registry/DefinitionBuilderRegistry.php
@@ -20,7 +20,7 @@ class DefinitionBuilderRegistry implements DefinitionBuilderRegistryInterface
         $this->registryStorage->store($service, DocumentDefinitionBuilderInterface::class, 'documentDefinitionBuilder', get_class($service));
     }
 
-    public function registerFilterDefinition(DocumentDefinitionBuilderInterface $service): void
+    public function registerFilterDefinition(FilterDefinitionBuilderInterface $service): void
     {
         $this->registryStorage->store($service, FilterDefinitionBuilderInterface::class, 'filterDefinitionBuilder', get_class($service));
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #45 

Fixes the wrong argument type in DefinitionBuilderRegistry::registerFilterDefinition

