### PR TITLE
fix error with more than one index overwriting options in $this->vali…

### DIFF
--- a/src/DynamicSearchBundle/Manager/DataManager.php
+++ b/src/DynamicSearchBundle/Manager/DataManager.php
@@ -36,7 +36,7 @@ class DataManager implements DataManagerInterface
             throw new ProviderException('Invalid requested data provider', $dataProviderName);
         }
 
-        $dataProvider = $this->dataProviderRegistry->get($dataProviderName);
+        $dataProvider = clone($this->dataProviderRegistry->get($dataProviderName));
         $dataProvider->setOptions($contextDefinition->getDataProviderOptions($providerBehaviour));
 
         $this->validProviders[$cacheKey] = $dataProvider;


### PR DESCRIPTION


if you have more than one index the index options get overwritten during runtime $this->validProviders[$cacheKey]

options gets changed for all cachekeys!

allowed classes gets overwritten with values from second index
