### PR TITLE
Fix wrong parameter use in SearchController.php

### DIFF
--- a/src/DynamicSearchBundle/Controller/SearchController.php
+++ b/src/DynamicSearchBundle/Controller/SearchController.php
@@ -49,7 +49,7 @@ class SearchController extends AbstractController
         if ($outputChannelResult instanceof MultiOutputChannelResultInterface) {
             $params = [];
             foreach ($outputChannelResult->getResults() as $resultBlockIdentifier => $resultBlock) {
-                $params[] = $this->getOutputParameters($outputChannelResult);
+                $params[] = $this->getOutputParameters($resultBlock);
             }
 
             return $this->json($params);


### PR DESCRIPTION
Fixes multi-search JSON output (if no frontend_controller is used). 
$resultBlock should have been used in the `getOutputParameters()` method. 

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no (hopefully)
| Deprecations? | no
| Fixed tickets | none

