### PR TITLE
remove provider cache to avoid configuration sharing

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,7 @@
 
 ### 2.1.1
 - [IMPROVEMENT] Added getter for `DynamicSearchBundle\Resource\ResourceCandidate::$contextName` [#55](https://github.com/dachcom-digital/pimcore-dynamic-search/pull/55)
+- [BUGFIX] remove provider cache to avoid configuration sharing [#72](https://github.com/dachcom-digital/pimcore-dynamic-search/pull/72)
 
 ### 2.1.0
 - [IMPROVEMENT] return raw result data if no normalizer is defined [#63](https://github.com/dachcom-digital/pimcore-dynamic-search/issues/63)

--- a/src/DynamicSearchBundle/Manager/DataManager.php
+++ b/src/DynamicSearchBundle/Manager/DataManager.php
@@ -2,7 +2,6 @@
 
 namespace DynamicSearchBundle\Manager;
 
-use DynamicSearchBundle\Configuration\ConfigurationInterface;
 use DynamicSearchBundle\Context\ContextDefinitionInterface;
 use DynamicSearchBundle\Exception\ProviderException;
 use DynamicSearchBundle\Provider\DataProviderInterface;
@@ -10,27 +9,13 @@ use DynamicSearchBundle\Registry\DataProviderRegistryInterface;
 
 class DataManager implements DataManagerInterface
 {
-    protected ConfigurationInterface $configuration;
-    protected DataProviderRegistryInterface $dataProviderRegistry;
-
-    protected array $validProviders;
-
-    public function __construct(
-        ConfigurationInterface $configuration,
-        DataProviderRegistryInterface $dataProviderRegistry
-    ) {
-        $this->configuration = $configuration;
-        $this->dataProviderRegistry = $dataProviderRegistry;
+    public function __construct(protected DataProviderRegistryInterface $dataProviderRegistry)
+    {
     }
 
     public function getDataProvider(ContextDefinitionInterface $contextDefinition, string $providerBehaviour): DataProviderInterface
     {
         $dataProviderName = $contextDefinition->getDataProviderName();
-        $cacheKey = sprintf('%s_%s', $contextDefinition->getName(), $dataProviderName);
-
-        if (isset($this->validProviders[$cacheKey])) {
-            return $this->validProviders[$cacheKey];
-        }
 
         if (is_null($dataProviderName) || !$this->dataProviderRegistry->has($dataProviderName)) {
             throw new ProviderException('Invalid requested data provider', $dataProviderName);
@@ -38,8 +23,6 @@ class DataManager implements DataManagerInterface
 
         $dataProvider = $this->dataProviderRegistry->get($dataProviderName);
         $dataProvider->setOptions($contextDefinition->getDataProviderOptions($providerBehaviour));
-
-        $this->validProviders[$cacheKey] = $dataProvider;
 
         return $dataProvider;
     }

--- a/src/DynamicSearchBundle/Manager/IndexManager.php
+++ b/src/DynamicSearchBundle/Manager/IndexManager.php
@@ -2,7 +2,6 @@
 
 namespace DynamicSearchBundle\Manager;
 
-use DynamicSearchBundle\Configuration\ConfigurationInterface;
 use DynamicSearchBundle\Context\ContextDefinitionInterface;
 use DynamicSearchBundle\Exception\ProviderException;
 use DynamicSearchBundle\Filter\FilterInterface;
@@ -13,29 +12,15 @@ use DynamicSearchBundle\Registry\IndexProviderRegistryInterface;
 
 class IndexManager implements IndexManagerInterface
 {
-    protected ConfigurationInterface $configuration;
-    protected IndexProviderRegistryInterface $indexProviderRegistry;
-    protected IndexRegistryInterface $indexRegistry;
-    protected array $validProviders;
-
     public function __construct(
-        ConfigurationInterface $configuration,
-        IndexProviderRegistryInterface $indexProviderRegistry,
-        IndexRegistryInterface $indexRegistry
+        protected IndexProviderRegistryInterface $indexProviderRegistry,
+        protected IndexRegistryInterface $indexRegistry
     ) {
-        $this->configuration = $configuration;
-        $this->indexProviderRegistry = $indexProviderRegistry;
-        $this->indexRegistry = $indexRegistry;
     }
 
     public function getIndexProvider(ContextDefinitionInterface $contextDefinition): IndexProviderInterface
     {
         $indexProviderName = $contextDefinition->getIndexProviderName();
-        $cacheKey = sprintf('%s_%s', $contextDefinition->getName(), $indexProviderName);
-
-        if (isset($this->validProviders[$cacheKey])) {
-            return $this->validProviders[$cacheKey];
-        }
 
         if (is_null($indexProviderName) || !$this->indexProviderRegistry->has($indexProviderName)) {
             throw new ProviderException('Invalid requested index provider', $indexProviderName);
@@ -43,8 +28,6 @@ class IndexManager implements IndexManagerInterface
 
         $indexProvider = $this->indexProviderRegistry->get($indexProviderName);
         $indexProvider->setOptions($contextDefinition->getIndexProviderOptions());
-
-        $this->validProviders[$cacheKey] = $indexProvider;
 
         return $indexProvider;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | /no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #61

This is a follow-up of #61. 

It will remove provider cache since it's quite useless (All the heavy option resolving stuff is happening on container compiling time, so no worries here). But it also introduced a bug, explained in #61: If there are multiple context definitions, the options will be shared since we don't instantiate providers.

The perfect solution would be to fetch providers by factory pattern, which would also introduce a BC break.
