### PR TITLE
use microtime for envelope queue

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,7 +1,7 @@
 # Upgrade Notes
 
 ## 3.0.1
-- Use `microtime` for envelope queue to avoid wrong processing order. Execute `bin/console bin/console dynamic-search:check-queue'` before updating to this version
+- Use `microtime` for envelope queue to avoid wrong processing order. Execute `bin/console dynamic-search:check-queue'` before updating to this version
 
 ## Migrating from Version 2.x to Version 3.0.
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,8 @@
 # Upgrade Notes
 
+## 3.0.1
+- Use `microtime` for envelope queue to avoid wrong processing order. Execute `bin/console bin/console dynamic-search:check-queue'` before updating to this version
+
 ## Migrating from Version 2.x to Version 3.0.
 
 ### Breaking Changes

--- a/src/Queue/Data/Envelope.php
+++ b/src/Queue/Data/Envelope.php
@@ -11,7 +11,8 @@ class Envelope
         protected string $contextName,
         protected string $dispatchType,
         protected array $resourceMetaStack,
-        protected array $options
+        protected array $options,
+        protected ?float $creationTime = null
     ) {
     }
 
@@ -41,5 +42,10 @@ class Envelope
     public function getOptions(): array
     {
         return $this->options;
+    }
+
+    public function getCreationTime(): ?float
+    {
+        return $this->creationTime;
     }
 }

--- a/src/Queue/DataProcessor.php
+++ b/src/Queue/DataProcessor.php
@@ -49,7 +49,7 @@ class DataProcessor implements DataProcessorInterface
     {
         $envelopeData = $this->queueManager->getQueuedEnvelopes();
 
-        if (empty($envelopeData) || !is_array($envelopeData)) {
+        if (empty($envelopeData)) {
             return;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

This PR introduces a `creationTime` in `Envelope` to ensure a valid processing order in queue.