### PR TITLE
allow empty strings being submitted to index

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,7 @@
 # Upgrade Notes
 
 ## 3.0.1
+- [BUGFIX] allow empty strings being submitted [#81](https://github.com/dachcom-digital/pimcore-dynamic-search/issues/81)
 - Use `microtime` for envelope queue to avoid wrong processing order. Execute `bin/console dynamic-search:check-queue'` before updating to this version
 
 ## Migrating from Version 2.x to Version 3.0.

--- a/src/Generator/IndexDocumentGenerator.php
+++ b/src/Generator/IndexDocumentGenerator.php
@@ -202,14 +202,6 @@ class IndexDocumentGenerator implements IndexDocumentGeneratorInterface
                 sprintf('Error while transform field resource with service "%s": %s', $fieldTransformerName, $e->getMessage()));
         }
 
-        if ($transformedData === null) {
-            return null;
-        }
-
-        if ($transformedData === '') {
-            return null;
-        }
-
         return $transformedData;
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #81 

This PR fixes #81 by removing the check if the transformed data equals an empty string.
This will result in text fields being emptied in the index, if the transformation results in an empty string
