### PR TITLE
allow null values for index fields

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,7 @@
 # Upgrade Notes
 
+## 4.0.3
+- fix null values in index [#95](https://github.com/dachcom-digital/pimcore-dynamic-search/pull/95)
 ## 4.0.2
 - introduced backend ui event [#91](https://github.com/dachcom-digital/pimcore-dynamic-search/pull/91)
 ## 4.0.1

--- a/src/Generator/IndexDocumentGenerator.php
+++ b/src/Generator/IndexDocumentGenerator.php
@@ -94,11 +94,6 @@ class IndexDocumentGenerator implements IndexDocumentGeneratorInterface
             $dataTransformerOptions = $documentDefinitionOptions['data_transformer'];
             $transformedData = $this->dispatchResourceFieldTransformer($dataTransformerOptions, $resourceScaffolderName, $resourceContainer);
 
-            if ($transformedData === null) {
-                // no error: transformer is allowed to refuse data
-                continue;
-            }
-
             $optionFieldContainer = new OptionFieldContainer($fieldName, $transformedData);
             $indexDocument->addOptionField($optionFieldContainer);
         }
@@ -132,11 +127,6 @@ class IndexDocumentGenerator implements IndexDocumentGeneratorInterface
         $dataTransformerOptions = $fieldDefinitionOptions['data_transformer'];
 
         $transformedData = $this->dispatchResourceFieldTransformer($dataTransformerOptions, $resourceScaffolderName, $resourceContainer);
-
-        if ($transformedData === null) {
-            // no error: transformer is allowed to refuse data
-            return;
-        }
 
         if ($fieldType === 'pre_process_definition') {
 
@@ -202,6 +192,10 @@ class IndexDocumentGenerator implements IndexDocumentGeneratorInterface
                 sprintf('Error while transform field resource with service "%s": %s', $fieldTransformerName, $e->getMessage()));
         }
 
+        if ($transformedData === '') {
+            return null;
+        }
+
         return $transformedData;
     }
 
@@ -224,10 +218,6 @@ class IndexDocumentGenerator implements IndexDocumentGeneratorInterface
             throw new \Exception(
                 sprintf('Error while transform field index with service "%s": %s', $indexTypeName, $e->getMessage())
             );
-        }
-
-        if ($indexFieldData === null) {
-            return null;
         }
 
         return $indexFieldData;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #88 

This PR finally fixes the issue where field values weren't updated in index if the value was `null`.