### PR TITLE
Provide ds context config in backend ui

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,7 @@
 # Upgrade Notes
 
+## 4.0.4
+- provide ds settings in backend ui [#96](https://github.com/dachcom-digital/pimcore-dynamic-search/pull/96)
 ## 4.0.3
 - fix null values in index [#95](https://github.com/dachcom-digital/pimcore-dynamic-search/pull/95)
 ## 4.0.2

--- a/config/pimcore/routing.yaml
+++ b/config/pimcore/routing.yaml
@@ -10,6 +10,12 @@ dynamic_search.controller.admin.get_provider:
     options:
         expose: true
 
+dynamic_search.controller.admin.get_context_full_configuration:
+    path: /admin/dynamic-search/settings/context-full-configuration
+    defaults: { _controller: DynamicSearchBundle\Controller\Admin\SettingsController::contextFullConfigurationAction }
+    options:
+        expose: true
+
 dynamic_search.controller.json_search:
     path: /dynamic-search/{contextName}/j-{outputChannelName}
     defaults: { _controller: DynamicSearchBundle\Controller\SearchController::jsonSearchAction }

--- a/config/services/controller.yaml
+++ b/config/services/controller.yaml
@@ -14,5 +14,7 @@ services:
             - 'controller.service_arguments'
 
     DynamicSearchBundle\Controller\Admin\SettingsController:
+        arguments:
+            $contextFullConfiguration: '%dynamic_search.context.full_configuration%'
         tags:
             - 'controller.service_arguments'

--- a/public/js/backend/startup.js
+++ b/public/js/backend/startup.js
@@ -8,17 +8,25 @@ class DynamicSearch {
             return;
         }
 
-        searchMenu = new Ext.Action({
-            id: 'search',
-            text: t('dynamic_search_settings'),
-            iconCls: 'dynamic_search_bundle',
-            handler: this.openSettingsPanel.bind(this)
+        Ext.Ajax.request({
+            url: Routing.generate('dynamic_search.controller.admin.get_context_full_configuration'),
+            success: function(response) {
+                const contextFullConfig = Ext.decode(response.responseText);
+                pimcore.globalmanager.add('dynamic_search.context.full_configuration', contextFullConfig);
+            },
+            callback: function() {
+                searchMenu = new Ext.Action({
+                    id: 'search',
+                    text: t('dynamic_search_settings'),
+                    iconCls: 'dynamic_search_bundle',
+                    handler: this.openSettingsPanel.bind(this)
+                });
+
+                if (layoutToolbar.settingsMenu) {
+                    layoutToolbar.settingsMenu.add(searchMenu);
+                }
+            }.bind(this)
         });
-
-        if (layoutToolbar.settingsMenu) {
-            layoutToolbar.settingsMenu.add(searchMenu);
-        }
-
     }
 
     openSettingsPanel() {

--- a/src/Controller/Admin/SettingsController.php
+++ b/src/Controller/Admin/SettingsController.php
@@ -10,6 +10,12 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 
 class SettingsController extends AdminAbstractController
 {
+    public function __construct(
+        private array $contextFullConfiguration
+    )
+    {
+    }
+
     public function healthStateAction(HealthStateRegistryInterface $healthStateRegistry): JsonResponse
     {
         $stateLines = [];
@@ -43,5 +49,10 @@ class SettingsController extends AdminAbstractController
         return $this->json([
             'provider' => $providerBundleLocator->findProviderBundles()
         ]);
+    }
+
+    public function contextFullConfigurationAction(ProviderBundleLocator $providerBundleLocator): JsonResponse
+    {
+        return $this->json($this->contextFullConfiguration);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no

This PR provides the full context configuration (parameter `dynamic_search.context.full_configuration`) to the backend ui (pimcore's globalmanager).
It can be queried with `pimcore.globalmanager.get('dynamic_search.context.full_configuration')`
