### PR TITLE
allow `data_transformer` to accept `null` values and handle null resource field transformers

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,7 @@
 
 ## 4.0.9
 - [BUGFIX] fixed document deletion [see more](https://github.com/dachcom-digital/pimcore-dynamic-search/pull/108)
+- [IMPROVEMENT] allow `data_transformer` to accept `null` values and handle null resource field transformers
 ## 4.0.8
 - [IMPROVEMENT] `dynamic_search.element_listener_options.allowed_document_types` added, read more about it [here](./docs/01_DispatchWorkflow.md#listener)
 ## 4.0.7

--- a/src/Document/Definition/DocumentDefinition.php
+++ b/src/Document/Definition/DocumentDefinition.php
@@ -67,7 +67,7 @@ class DocumentDefinition implements DocumentDefinitionInterface
         $resolver = new OptionsResolver();
         $resolver->setRequired(['name', 'data_transformer']);
         $resolver->setAllowedTypes('name', ['string']);
-        $resolver->setAllowedTypes('data_transformer', ['array']);
+        $resolver->setAllowedTypes('data_transformer', ['array', 'null']);
 
         try {
             $options = $resolver->resolve($definition);
@@ -100,7 +100,7 @@ class DocumentDefinition implements DocumentDefinitionInterface
         $resolver->setRequired(['name', 'index_transformer', 'data_transformer']);
         $resolver->setAllowedTypes('name', ['string']);
         $resolver->setAllowedTypes('index_transformer', ['array']);
-        $resolver->setAllowedTypes('data_transformer', ['array']);
+        $resolver->setAllowedTypes('data_transformer', ['array', 'null']);
 
         try {
             $options = $resolver->resolve($definition);

--- a/src/Generator/IndexDocumentGenerator.php
+++ b/src/Generator/IndexDocumentGenerator.php
@@ -180,9 +180,15 @@ class IndexDocumentGenerator implements IndexDocumentGeneratorInterface
     /**
      * @throws \Exception
      */
-    protected function dispatchResourceFieldTransformer(array $options, string $dispatchTransformerName, ResourceContainerInterface $resourceContainer): mixed
+    protected function dispatchResourceFieldTransformer(?array $options, string $dispatchTransformerName, ResourceContainerInterface $resourceContainer): mixed
     {
         $fieldTransformerName = $options['type'];
+
+        // it's not a source field
+        if ($fieldTransformerName === null) {
+            return null;
+        }
+
         $fieldTransformerConfiguration = $options['configuration'];
 
         $fieldTransformer = $this->transformerManager->getResourceFieldTransformer($dispatchTransformerName, $fieldTransformerName, $fieldTransformerConfiguration);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

E.g. embedded vecor fields
